### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gemini-audit.yml
+++ b/.github/workflows/gemini-audit.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '0 0 * * 1' # Every Monday
 
+permissions:
+  contents: read
+
 jobs:
   audit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/MOHD-TAHA-KHAN/Job_Referral_Network_System/security/code-scanning/1](https://github.com/MOHD-TAHA-KHAN/Job_Referral_Network_System/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/gemini-audit.yml` so the workflow does not rely on repo/org defaults. The best minimal fix, without changing current intended functionality unnecessarily, is to set workflow-level permissions to read-only for repository contents:

- Insert `permissions:` at the top level (after triggers and before `jobs:`).
- Set `contents: read` as the minimal least-privilege baseline recommended by CodeQL.
- Keep all existing jobs and steps unchanged.

This addresses the warning directly and documents token scope in the workflow itself.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Declare workflow-level permissions for repository contents as read-only in the gemini-audit GitHub Actions workflow.