### PR TITLE
ci: pin actions/checkout to full SHA (copilot setup)

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,4 +1,4 @@
-name: "Copilot Setup Steps"
+﻿name: "Copilot Setup Steps"
 
 # This workflow configures the environment for GitHub Copilot Agent with gh-aw MCP server
 on:
@@ -19,8 +19,9 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Install gh-aw extension
         uses: github/gh-aw-actions/setup-cli@b8068426813005612b960b5ab0b8bd2c27142323 # v0.71.5
         with:
           version: v0.71.5
+


### PR DESCRIPTION
Pin actions/checkout to a full commit SHA to comply with repository policy. This should allow workflows to run.\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

## Summary by Sourcery

CI:
- Update the Copilot setup workflow to use actions/checkout via a full commit SHA instead of a version tag.