### PR TITLE
docs: add wiki link and enable wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,3 +306,8 @@ Built with passion by a fresher, for freshers.
 ## 📄 License
 
 This project is licensed under the **Apache License 2.0** — see the [LICENSE](LICENSE) file for details.
+
+## Wiki
+This repository's GitHub Wiki has been enabled: https://github.com/MOHD-TAHA-KHAN/Job_Referral_Network_System/wiki
+
+Please add pages to the wiki for architecture, deployment, contribution guidelines, and runbook documentation.


### PR DESCRIPTION
This PR enables the repository Wiki and adds a link to README.\n\nEnables collaborative documentation via GitHub Wiki.

## Summary by Sourcery

Documentation:
- Add a Wiki section to the README linking to the repository's GitHub Wiki and suggesting key documentation topics to cover.