### PR TITLE
docs: add initial docs pages

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -1,0 +1,23 @@
+﻿# Architecture
+
+Overview
+This repository is split into major components:
+- client/: React + TypeScript single-page app (UI, routing, forms)
+- server/: Node.js + Express REST API (business logic, auth)
+- database/: PostgreSQL schema, migrations, seeders
+- realtime/: Socket.io (notifications, presence)
+- auth: JWT-based tokens with refresh flow
+- jobs/cron: scheduled matching and notification tasks
+
+High-level data flow
+1. Client → Server: API requests for reads/writes
+2. Server → DB: transactional writes (referral, user, matches)
+3. Matching engine: scores candidates periodically or on-demand
+4. Notifications: events delivered via Socket.io to clients
+
+Operational diagram
+(Consider adding a Mermaid or image here)
+
+Notes
+- Keep heavy computation in worker processes (avoid blocking web requests).
+- Document schema changes in database/ and update migrations.

--- a/docs/Contribution.md
+++ b/docs/Contribution.md
@@ -1,0 +1,24 @@
+﻿# Contributing
+
+Welcome! Suggested workflow
+1. Fork the repo; create a branch: feat/short-description or fix/short-description
+2. Implement changes, add tests, run linters locally
+3. Open a PR describing the change and link any related issues
+
+PR checklist
+- Title: type(scope): short summary (e.g., feat(client): add profile redirect)
+- Include tests for critical logic
+- Update README or docs if behavior or setup changed
+- Add reviewers and assign related issues
+
+Coding conventions
+- TypeScript: use strict types where practical
+- Logging: avoid console.log in production; use structured logger (winston/pino)
+- Tests: unit for core logic + integration for critical flows
+
+Issue triage
+- Use labels: bug, enhancement, help wanted, good first issue
+- Break large tasks into smaller issues/PRs
+
+Code of Conduct
+Add your organization code of conduct or link to one.

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -1,0 +1,1 @@
+﻿C:\Users\mohdt

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -1,1 +1,28 @@
-﻿C:\Users\mohdt
+﻿# Job Referral Network System
+
+A referral platform connecting candidates, referrers, and employers with real-time notifications and a matching engine.
+
+Status
+- Repo: active
+- CI: check .github/workflows
+- Deploy: Docker / docker-compose (see Setup)
+
+Quick start
+1. git clone https://github.com/MOHD-TAHA-KHAN/Job_Referral_Network_System.git
+2. cp .env.example .env and fill values
+3. docker-compose up --build
+4. cd server && npm install && npm run dev
+5. cd ../client && npm install && npm start
+
+Repository docs
+- Architecture — docs/Architecture.md
+- Setup — docs/Setup.md
+- Contribution — docs/Contribution.md
+- Runbook — docs/Runbook.md
+
+Maintainers & contact
+- Maintainers: add names or team here
+- Report issues: use Issues tab
+
+License
+- See LICENSE in repo root

--- a/docs/Runbook.md
+++ b/docs/Runbook.md
@@ -1,0 +1,31 @@
+﻿# Runbook
+
+Quick operational tasks
+- Restart services:
+  - docker-compose restart
+  - Or restart specific services (pm2 or systemd if used)
+- Tail logs:
+  - docker-compose logs -f
+  - server stdout: check container or cloud logs
+
+Common incidents
+- DB connection errors:
+  1. Check DB container status: docker ps
+  2. Check env vars (DATABASE_URL)
+  3. Restart DB container; run migrations
+
+- High CPU or long-running matching jobs:
+  - Inspect worker logs
+  - Pause scheduled job or scale workers
+
+Secrets rotation
+- Update GitHub Secrets via repo Settings → Secrets
+- Restart services after rotating critical secrets
+
+Escalation
+- Primary: @maintainer1
+- Secondary: @maintainer2
+
+Runbook maintenance
+- Keep this page updated with exact commands and contact details.
+- Add step-by-step rollback and recovery instructions for each critical service.

--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -1,0 +1,31 @@
+﻿# Setup
+
+Prerequisites
+- Node.js 18+ and npm (or yarn)
+- Docker & docker-compose (for Postgres & optional services)
+- Git and GitHub access for push/PR
+- Create a GitHub repo secret store for credentials
+
+Local development (quick)
+1. git clone https://github.com/MOHD-TAHA-KHAN/Job_Referral_Network_System.git
+2. cp .env.example .env and fill values
+3. cd server && npm install
+4. cd ../client && npm install
+5. docker-compose up --build (starts Postgres and other services)
+6. In server: npm run dev
+7. In client: npm start
+
+Database
+- Migrations: see database/ (describe migration tool and commands)
+- To reset locally: docker-compose down -v && docker-compose up --build
+
+Testing
+- Backend: cd server && npm test
+- Frontend: cd client && npm test
+
+CI / Deployment
+- See .github/workflows for automated checks
+- Use pinned action SHAs (repo enforces pinning)
+
+Security
+- Do not commit secrets. Use GitHub Secrets and env vars.


### PR DESCRIPTION
Adds initial docs/ pages: Home, Architecture, Setup, Contribution, Runbook. These provide repository documentation in-tree as a stable alternative to the GitHub Wiki.

## Summary by Sourcery

Add an initial in-repo documentation set covering architecture, setup, contribution guidelines, and operational runbooks for the project.

Documentation:
- Add setup guide covering prerequisites, local development workflow, database usage, testing, CI/deployment notes, and security expectations.
- Add architecture overview describing core components, data flow, and operational notes.
- Add contributing guide outlining workflow, PR expectations, coding conventions, and issue triage guidance.
- Add operational runbook for common incidents, log inspection, secrets rotation, and escalation contacts.
- Add initial home/docs entry point file for the documentation section.