### PR TITLE
chore: add Vercel serverless wrapper for backend

### DIFF
--- a/server/api/index.js
+++ b/server/api/index.js
@@ -1,0 +1,15 @@
+﻿const serverless = require('serverless-http');
+
+// Import the compiled Express app from dist.
+// Vercel will run `npm run build` (tsc) during the build step, producing server/dist/app.js
+// which exports the Express `app` as the default export (app.ts: `export default app`).
+let app;
+try {
+  app = require('../dist/app').default || require('../dist/app');
+} catch (err) {
+  // If dist is not present at runtime, provide a helpful error
+  console.error('Failed to require ../dist/app. Ensure TypeScript is compiled (npm run build) during Vercel build. Error:', err);
+  throw err;
+}
+
+module.exports = serverless(app);

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "node dist/app.js",
     "dev": "nodemon --exec ts-node app.ts",
-    "build": "tsc"
+    "build": "tsc",
+    "vercel-build": "npm run build"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Adds server/api/index.js as serverless wrapper and vercel-build script in package.json.\n\nDeploy backend as a separate Vercel project with root=server. Set server env vars: PG_URI, JWT_SECRET, JWT_REFRESH_SECRET, CLIENT_URL, GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, CLOUDINARY_URL, EMAIL_USER, EMAIL_PASS. Frontend should point VITE_API_URL to the backend domain.

## Summary by Sourcery

Add a serverless wrapper entrypoint for the backend and wire it into the build process for Vercel deployment.

Build:
- Add a vercel-build script that compiles the TypeScript backend before deployment.

Deployment:
- Introduce a serverless HTTP wrapper entrypoint under server/api for running the compiled Express app on Vercel.