### PR TITLE
Update GitHub Actions checkout and Vercel action versions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,9 +11,9 @@ jobs:
   deploy-frontend:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
       - name: Deploy to Vercel
-        uses: amondnet/vercel-action@v20
+        uses: amondnet/vercel-action@3f92e69c8521ec0ee22fedaa69c4e5bc48d72fec
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Pin GitHub Actions checkout and Vercel deployment actions in the CD workflow to fixed commit SHAs instead of floating version tags.